### PR TITLE
Fix running NSxfer on CPUs prior to the Pentium 2 by using -march=i486.

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -39,7 +39,7 @@ ifeq ($(ARCH), X64)
 	RCFLAGS += -F pe-x86-64
 else
 	PREFIX  := $(PREFIX32)
-	CFLAGS  += -march=pentium2 -DNDEBUG
+	CFLAGS  += -march=i486 -DNDEBUG
 	LDFLAGS += -Wl,-e'_DllMain'
 	RCFLAGS += -F pe-i386
 endif


### PR DESCRIPTION
Tested on Windows 2000 on a Pentium MMX 233.

Goes along with the fix for Issue #154 in the LegacyUpdate repository.